### PR TITLE
Fix connection fail between API and DDB

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -1,0 +1,1 @@
+DATABASE_HOST=localhost

--- a/api/ormconfig.ts
+++ b/api/ormconfig.ts
@@ -3,7 +3,7 @@ import { SnakeNamingStrategy } from "typeorm-naming-strategies"
 
 const ormConfig: DataSourceOptions = {
   type: "postgres",
-  host: "localhost",
+  host: process.env.DATABASE_HOST,
   port: 5432,
   username: "postgres",
   password: "admin",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
     depends_on:
       - postgres
     environment:
-      JWT_KEY: 0ZhFgrduv8M1tha164qygCCV2E6n97r5
       DATABASE_HOST: postgres
     command: sh -c "yarn install && yarn start"
 


### PR DESCRIPTION
Problème de connexion entre l'API et le base de données, en raison d'une variable docker inutilisé DATABASE_HOST.

Solution:

création d'un .env avec la nouvelle variable DATABASE_HOST=localhost